### PR TITLE
Miglioramento Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ install-doc:
 
 install-test:
 	@echo "🟡 Installing testing dependencies ..."
-	$(VENV_PYTHON) -m pip install -r $(INSTALL_DIR)/requirements-test.txt # TODO: creare
+	$(VENV_PYTHON) -m pip install -r $(INSTALL_DIR)/requirements-test.txt
 	@echo "test dependencies installed ✅"
 	@echo ""
 

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,0 +1,2 @@
+scikit-network==0.28
+timeout-decorator

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,1 +1,0 @@
-python -m unittest discover -v -s tests/

--- a/tests/Configs.py
+++ b/tests/Configs.py
@@ -1,0 +1,30 @@
+import networkx as nx
+from sknetwork.data import house, karate_club, load_konect
+
+
+class Configs:
+    dataset_easy = house()
+    dataset_medium = karate_club()
+    dataset_hard = load_konect('ego-facebook', verbose=False)["adjacency"]
+    timeout = 5 * 60  # 5 minuit
+
+    @staticmethod
+    def load_easy_dataset():
+        adj = Configs.dataset_easy
+        g = nx.from_numpy_array(adj)
+
+        return g, adj
+
+    @staticmethod
+    def load_medium_dataset():
+        adj = Configs.dataset_medium
+        g = nx.from_numpy_array(adj)
+
+        return g, adj
+
+    @staticmethod
+    def load_hard_dataset():
+        adj = Configs.dataset_hard
+        g = nx.from_numpy_array(adj)
+
+        return g, adj

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .Configs import Configs

--- a/tests/dimensionality_reduction/test_svd.py
+++ b/tests/dimensionality_reduction/test_svd.py
@@ -1,6 +1,6 @@
 import unittest
 from social_network_link_prediction.similarity_methods import dimensionality_reduction
-from socketserver.embedding import SVD
+from sknetwork.embedding import SVD
 from tests import Configs
 from time import time
 from timeout_decorator import timeout

--- a/tests/dimensionality_reduction/test_svd.py
+++ b/tests/dimensionality_reduction/test_svd.py
@@ -9,6 +9,7 @@ import networkit as nk
 class TestDimensionalityReductionMethods(unittest.TestCase):
 
     # TODO: ricontrollare
+    @unittest.skip("Metodo non ancora implementato")
     def test_svd(self):
         from socketserver.embedding import SVD
 

--- a/tests/dimensionality_reduction/test_svd.py
+++ b/tests/dimensionality_reduction/test_svd.py
@@ -1,26 +1,40 @@
 import unittest
 from social_network_link_prediction.similarity_methods import dimensionality_reduction
-import networkx as nx
-from sknetwork.data import karate_club
-import numpy as np
-import networkit as nk
+from socketserver.embedding import SVD
+from tests import Configs
+from time import time
+from timeout_decorator import timeout
 
 
 class TestDimensionalityReductionMethods(unittest.TestCase):
 
+    def setUp(self):
+        self.start_time = time()
+
+    def tearDown(self):
+        t = time() - self.start_time
+
+        print(f"{round(t, 2)} s")
+
     # TODO: ricontrollare
     @unittest.skip("Metodo non ancora implementato")
-    def test_svd(self):
-        from socketserver.embedding import SVD
-
-        adjacency = karate_club()
-        G = nx.from_numpy_array(adjacency)
+    def test_svd_3(self):
+        g, adjacency = Configs.load_hard_dataset()
 
         svd = SVD()
         embedding = svd.fit_transform(adjacency)
-        our_embedding = dimensionality_reduction.svd(G)
+        our_embedding = dimensionality_reduction.svd(g)
 
         self.assertEqual(embedding, our_embedding)
+
+    @unittest.skip("Metodo non ancora implementato")
+    @timeout(Configs.timeout)
+    def test_svd_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+
+        our_embedding = dimensionality_reduction.svd(g)
+
+        self.assertIsNotNone(our_embedding)
 
 
 if __name__ == '__main__':

--- a/tests/similarity_methods/test_global.py
+++ b/tests/similarity_methods/test_global.py
@@ -9,6 +9,8 @@ import networkit as nk
 class TestGlobalSimilarityMethods(unittest.TestCase):
 
     # TODO: @Cosci, anche questa implementazione non va
+    @unittest.skip(
+        "Il metodo di Networkit differisce nell'implementazione dal nostro")
     def test_katz(self):
         from networkit.linkprediction import KatzIndex
 

--- a/tests/similarity_methods/test_global.py
+++ b/tests/similarity_methods/test_global.py
@@ -1,42 +1,44 @@
 import unittest
 from social_network_link_prediction.similarity_methods import global_similarity
-import networkx as nx
-from sknetwork.data import house
-import networkit as nk
+from timeout_decorator import timeout
+from tests import Configs
+from time import time
 
 
 class TestGlobalSimilarityMethods(unittest.TestCase):
 
-    # TODO: @Cosci, anche questa implementazione non va
+    def setUp(self):
+        self.start_time = time()
+
+    def tearDown(self):
+        t = time() - self.start_time
+
+        print(f"{round(t, 2)} s")
+
     @unittest.skip(
         "Il metodo di Networkit differisce nell'implementazione dal nostro")
-    def test_katz(self):
-        from networkit.linkprediction import KatzIndex
+    def test_katz_1(self):
+        pass
 
-        adjacency = house()
+    @unittest.skip(
+        "Il metodo di Networkit differisce nell'implementazione dal nostro")
+    def test_katz_2(self):
+        pass
 
-        beta = .3
+    @unittest.skip(
+        "Il metodo di Networkit differisce nell'implementazione dal nostro")
+    def test_katz_3(self):
+        pass
 
-        G = nx.from_numpy_array(adjacency)
-        G_nk = nk.Graph(G.number_of_nodes())
+    @timeout(Configs.timeout)
+    def test_katz_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+        beta = .001
 
-        for edge in G.edges():
-            G_nk.addEdge(*edge)
+        res = global_similarity.katz_index(g, beta=beta)
+        # print(res)
 
-        print(nk.overview(G_nk))
-
-        kaz = KatzIndex(G_nk, 10, beta)
-
-        # ritorna la similarità solo tra nodi non connessi
-        scores_nk = kaz.runAll()
-        our_scores = global_similarity.katz_index(G, beta=beta).toarray()
-
-        print()
-        print(scores_nk)
-        print()
-        print(our_scores)
-
-        self.assertEqual(scores_nk, our_scores)
+        self.assertIsNotNone(res)
 
 
 if __name__ == '__main__':

--- a/tests/similarity_methods/test_global.py
+++ b/tests/similarity_methods/test_global.py
@@ -2,7 +2,6 @@ import unittest
 from social_network_link_prediction.similarity_methods import global_similarity
 import networkx as nx
 from sknetwork.data import house
-import numpy as np
 import networkit as nk
 
 

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -1,48 +1,107 @@
-import unittest
-from social_network_link_prediction.similarity_methods import local_similarity
 import networkx as nx
-from sknetwork.data import house
+import unittest
 import random
+from social_network_link_prediction.similarity_methods import local_similarity
+from sknetwork.data import house, karate_club, load_konect
+from sknetwork.linkpred import CommonNeighbors
+from sknetwork.linkpred import JaccardIndex
 
 
 class TestLocalSimilarityMethods(unittest.TestCase):
+    __dataset_easy = house()
+    __dataset_medium = karate_club()
+    __dataset_hard = load_konect('ego-facebook', verbose=False)["adjacency"]
 
-    def test_common_neighbors(self):
-        from sknetwork.linkpred import CommonNeighbors
+    def __load_easy_dataset(self):
+        adj = self.__dataset_easy
+        g = nx.from_numpy_array(adj)
 
-        adjacency = house()
+        return g, adj
+
+    def __load_medium_dataset(self):
+        adj = self.__dataset_medium
+        g = nx.from_numpy_array(adj)
+
+        return g, adj
+
+    def __load_hard_dataset(self):
+        adj = self.__dataset_hard
+        g = nx.from_numpy_array(adj)
+
+        return g, adj
+
+    def __perform_sktest(self,
+                         our_values,
+                         skfunction,
+                         samples_range,
+                         samples_number=20):
+        indxes = [(random.randrange(samples_range),
+                   random.randrange(samples_range))
+                  for a in range(samples_number)]
+
+        for i, j in indxes:
+            expected = skfunction.predict((i, j))
+            our_res = our_values[i, j]
+
+            self.assertEqual(expected.round(2), our_res.round(2))
+
+    def test_common_neighbors_1(self):
+        g, adjacency = self.__load_easy_dataset()
         cn = CommonNeighbors()
 
         cn.fit(adjacency)
-        our_sim = local_similarity.common_neighbors(
-            nx.from_numpy_array(adjacency))
+        our_sim = local_similarity.common_neighbors(g)
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0], 20)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+    def test_common_neighbors_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-            self.assertEqual(expected, our_res)
+        cn = CommonNeighbors()
+        cn.fit(adjacency)
 
-    def test_jaccard(self):
-        from sknetwork.linkpred import JaccardIndex
+        our_sim = local_similarity.common_neighbors(g)
 
-        adjacency = house()
-        cn = JaccardIndex()
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_common_neighbors_3(self):
+        g, adjacency = self.__load_hard_dataset()
+        cn = CommonNeighbors()
 
         cn.fit(adjacency)
-        our_sim = local_similarity.jaccard(nx.from_numpy_array(adjacency))
+        our_sim = local_similarity.common_neighbors(g)
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+    def test_jaccard_1(self):
+        g, adjacency = self.__load_easy_dataset()
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+        cn = JaccardIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.jaccard(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_jaccard_2(self):
+        g, adjacency = self.__load_medium_dataset()
+
+        cn = JaccardIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.jaccard(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_jaccard_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = JaccardIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.jaccard(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_sorensen(self):
         from sknetwork.linkpred import SorensenIndex

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -40,7 +40,8 @@ class TestLocalSimilarityMethods(unittest.TestCase):
                          our_values,
                          skfunction,
                          samples_range,
-                         samples_number=20):
+                         samples_number=20,
+                         decimal_precision=3):
         indxes = [(random.randrange(samples_range),
                    random.randrange(samples_range))
                   for a in range(samples_number)]
@@ -49,7 +50,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
             expected = skfunction.predict((i, j))
             our_res = our_values[i, j]
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+            self.assertAlmostEqual(expected, our_res, decimal_precision)
 
     def test_common_neighbors_1(self):
         g, adjacency = self.__load_easy_dataset()

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import unittest
 import random
+from timeout_decorator import timeout
 from social_network_link_prediction.similarity_methods import local_similarity
 from sknetwork.data import house, karate_club, load_konect
 from sknetwork.linkpred import CommonNeighbors
@@ -17,6 +18,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
     __dataset_easy = house()
     __dataset_medium = karate_club()
     __dataset_hard = load_konect('ego-facebook', verbose=False)["adjacency"]
+    __timeout = 5 * 60  # 5 minuit
 
     def __load_easy_dataset(self):
         adj = self.__dataset_easy
@@ -71,6 +73,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_common_neighbors_3(self):
         g, adjacency = self.__load_hard_dataset()
         cn = CommonNeighbors()
@@ -100,6 +103,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_jaccard_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -130,6 +134,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_sorensen_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -160,6 +165,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_hubpromoted_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -190,6 +196,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_hubdepressede_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -220,6 +227,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_adamicadar_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -250,6 +258,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_resourceallocation_3(self):
         g, adjacency = self.__load_hard_dataset()
 
@@ -280,6 +289,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
+    @timeout(__timeout)
     def test_preferentialattachment_3(self):
         g, adjacency = self.__load_hard_dataset()
 

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -286,12 +286,44 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     @unittest.skip("Non è presente in scikit-network")
-    def test_cosine(self):
+    def test_cosine_1(self):
         pass
 
     @unittest.skip("Non è presente in scikit-network")
-    def test_nodeclustering(self):
+    def test_cosine_2(self):
         pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_cosine_3(self):
+        pass
+
+    @timeout(Configs.timeout)
+    def test_cosine_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+
+        our_sim = local_similarity.cosine_similarity(g)
+
+        self.assertIsNotNone(our_sim)
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_nodeclustering_1(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_nodeclustering_2(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_nodeclustering_3(self):
+        pass
+
+    @timeout(Configs.timeout)
+    def test_nodeclustering_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+
+        our_sim = local_similarity.node_clustering(g)
+
+        self.assertIsNotNone(our_sim)
 
 
 if __name__ == '__main__':

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -1,4 +1,3 @@
-import networkx as nx
 import unittest
 import random
 from timeout_decorator import timeout
@@ -16,10 +15,6 @@ from tests import Configs
 
 
 class TestLocalSimilarityMethods(unittest.TestCase):
-    __dataset_easy = Configs.dataset_easy
-    __dataset_medium = Configs.dataset_medium
-    __dataset_hard = Configs.dataset_hard
-    __timeout = Configs.timeout
 
     def setUp(self):
         self.start_time = time()
@@ -27,24 +22,6 @@ class TestLocalSimilarityMethods(unittest.TestCase):
     def tearDown(self):
         t = time() - self.start_time
         print(f"{round(t, 2)} s")
-
-    def __load_easy_dataset(self):
-        adj = self.__dataset_easy
-        g = nx.from_numpy_array(adj)
-
-        return g, adj
-
-    def __load_medium_dataset(self):
-        adj = self.__dataset_medium
-        g = nx.from_numpy_array(adj)
-
-        return g, adj
-
-    def __load_hard_dataset(self):
-        adj = self.__dataset_hard
-        g = nx.from_numpy_array(adj)
-
-        return g, adj
 
     def __perform_sktest(self,
                          our_values,
@@ -63,7 +40,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
             self.assertAlmostEqual(expected, our_res, decimal_precision)
 
     def test_common_neighbors_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
         cn = CommonNeighbors()
 
         cn.fit(adjacency)
@@ -72,7 +49,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0], 20)
 
     def test_common_neighbors_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = CommonNeighbors()
         cn.fit(adjacency)
@@ -81,9 +58,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_common_neighbors_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
         cn = CommonNeighbors()
 
         cn.fit(adjacency)
@@ -92,7 +69,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_jaccard_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = JaccardIndex()
         cn.fit(adjacency)
@@ -102,7 +79,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_jaccard_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = JaccardIndex()
         cn.fit(adjacency)
@@ -111,9 +88,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_jaccard_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = JaccardIndex()
         cn.fit(adjacency)
@@ -123,7 +100,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_sorensen_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = SorensenIndex()
         cn.fit(adjacency)
@@ -133,7 +110,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_sorensen_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = SorensenIndex()
         cn.fit(adjacency)
@@ -142,9 +119,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_sorensen_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = SorensenIndex()
         cn.fit(adjacency)
@@ -154,7 +131,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_hubpromoted_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = HubPromotedIndex()
         cn.fit(adjacency)
@@ -164,7 +141,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_hubpromoted_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = HubPromotedIndex()
         cn.fit(adjacency)
@@ -173,9 +150,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_hubpromoted_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = HubPromotedIndex()
         cn.fit(adjacency)
@@ -185,7 +162,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_hubdepressed_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = HubDepressedIndex()
         cn.fit(adjacency)
@@ -195,7 +172,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_hubdepressed_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = HubDepressedIndex()
         cn.fit(adjacency)
@@ -204,9 +181,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_hubdepressede_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = HubDepressedIndex()
         cn.fit(adjacency)
@@ -216,7 +193,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_adamicadar_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = AdamicAdar()
         cn.fit(adjacency)
@@ -226,7 +203,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_adamicadar_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = AdamicAdar()
         cn.fit(adjacency)
@@ -235,9 +212,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_adamicadar_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = AdamicAdar()
         cn.fit(adjacency)
@@ -247,7 +224,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_resourceallocation_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = ResourceAllocation()
         cn.fit(adjacency)
@@ -257,7 +234,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_resourceallocation_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = ResourceAllocation()
         cn.fit(adjacency)
@@ -266,9 +243,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_resourceallocation_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = ResourceAllocation()
         cn.fit(adjacency)
@@ -278,7 +255,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_preferentialattachment_1(self):
-        g, adjacency = self.__load_easy_dataset()
+        g, adjacency = Configs.load_easy_dataset()
 
         cn = PreferentialAttachment()
         cn.fit(adjacency)
@@ -288,7 +265,7 @@ class TestLocalSimilarityMethods(unittest.TestCase):
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     def test_preferentialattachment_2(self):
-        g, adjacency = self.__load_medium_dataset()
+        g, adjacency = Configs.load_medium_dataset()
 
         cn = PreferentialAttachment()
         cn.fit(adjacency)
@@ -297,9 +274,9 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    @timeout(__timeout)
+    @timeout(Configs.timeout)
     def test_preferentialattachment_3(self):
-        g, adjacency = self.__load_hard_dataset()
+        g, adjacency = Configs.load_hard_dataset()
 
         cn = PreferentialAttachment()
         cn.fit(adjacency)

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -2,8 +2,8 @@ import networkx as nx
 import unittest
 import random
 from timeout_decorator import timeout
+from time import time
 from social_network_link_prediction.similarity_methods import local_similarity
-from sknetwork.data import house, karate_club, load_konect
 from sknetwork.linkpred import CommonNeighbors
 from sknetwork.linkpred import JaccardIndex
 from sknetwork.linkpred import SorensenIndex
@@ -12,13 +12,21 @@ from sknetwork.linkpred import HubDepressedIndex
 from sknetwork.linkpred import AdamicAdar
 from sknetwork.linkpred import ResourceAllocation
 from sknetwork.linkpred import PreferentialAttachment
+from tests import Configs
 
 
 class TestLocalSimilarityMethods(unittest.TestCase):
-    __dataset_easy = house()
-    __dataset_medium = karate_club()
-    __dataset_hard = load_konect('ego-facebook', verbose=False)["adjacency"]
-    __timeout = 5 * 60  # 5 minuit
+    __dataset_easy = Configs.dataset_easy
+    __dataset_medium = Configs.dataset_medium
+    __dataset_hard = Configs.dataset_hard
+    __timeout = Configs.timeout
+
+    def setUp(self):
+        self.start_time = time()
+
+    def tearDown(self):
+        t = time() - self.start_time
+        print(f"{round(t, 2)} s")
 
     def __load_easy_dataset(self):
         adj = self.__dataset_easy

--- a/tests/similarity_methods/test_local.py
+++ b/tests/similarity_methods/test_local.py
@@ -5,6 +5,12 @@ from social_network_link_prediction.similarity_methods import local_similarity
 from sknetwork.data import house, karate_club, load_konect
 from sknetwork.linkpred import CommonNeighbors
 from sknetwork.linkpred import JaccardIndex
+from sknetwork.linkpred import SorensenIndex
+from sknetwork.linkpred import HubPromotedIndex
+from sknetwork.linkpred import HubDepressedIndex
+from sknetwork.linkpred import AdamicAdar
+from sknetwork.linkpred import ResourceAllocation
+from sknetwork.linkpred import PreferentialAttachment
 
 
 class TestLocalSimilarityMethods(unittest.TestCase):
@@ -103,116 +109,185 @@ class TestLocalSimilarityMethods(unittest.TestCase):
 
         self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-    def test_sorensen(self):
-        from sknetwork.linkpred import SorensenIndex
+    def test_sorensen_1(self):
+        g, adjacency = self.__load_easy_dataset()
 
-        adjacency = house()
         cn = SorensenIndex()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.sorensen(nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.sorensen(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_sorensen_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-    def test_hubpromoted(self):
-        from sknetwork.linkpred import HubPromotedIndex
+        cn = SorensenIndex()
+        cn.fit(adjacency)
 
-        adjacency = house()
+        our_sim = local_similarity.sorensen(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_sorensen_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = SorensenIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.sorensen(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_hubpromoted_1(self):
+        g, adjacency = self.__load_easy_dataset()
+
         cn = HubPromotedIndex()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.hub_promoted(nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.hub_promoted(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_hubpromoted_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-    def test_hubdepressed(self):
-        from sknetwork.linkpred import HubDepressedIndex
+        cn = HubPromotedIndex()
+        cn.fit(adjacency)
 
-        adjacency = house()
+        our_sim = local_similarity.hub_promoted(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_hubpromoted_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = HubPromotedIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.hub_promoted(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_hubdepressed_1(self):
+        g, adjacency = self.__load_easy_dataset()
+
         cn = HubDepressedIndex()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.hub_depressed(
-            nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.hub_depressed(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_hubdepressed_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-    def test_adamicadar(self):
-        from sknetwork.linkpred import AdamicAdar
+        cn = HubDepressedIndex()
+        cn.fit(adjacency)
 
-        adjacency = house()
+        our_sim = local_similarity.hub_depressed(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_hubdepressede_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = HubDepressedIndex()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.hub_depressed(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_adamicadar_1(self):
+        g, adjacency = self.__load_easy_dataset()
+
         cn = AdamicAdar()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.adamic_adar(nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.adamic_adar(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_adamicadar_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-    def test_resourceallocation(self):
-        from sknetwork.linkpred import ResourceAllocation
+        cn = AdamicAdar()
+        cn.fit(adjacency)
 
-        adjacency = house()
+        our_sim = local_similarity.adamic_adar(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_adamicadar_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = AdamicAdar()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.adamic_adar(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_resourceallocation_1(self):
+        g, adjacency = self.__load_easy_dataset()
+
         cn = ResourceAllocation()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.resource_allocation(
-            nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.resource_allocation(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_resourceallocation_2(self):
+        g, adjacency = self.__load_medium_dataset()
 
-    def test_preferentialattachment(self):
-        from sknetwork.linkpred import PreferentialAttachment
+        cn = ResourceAllocation()
+        cn.fit(adjacency)
 
-        adjacency = house()
+        our_sim = local_similarity.resource_allocation(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_resourceallocation_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = ResourceAllocation()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.resource_allocation(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_preferentialattachment_1(self):
+        g, adjacency = self.__load_easy_dataset()
+
         cn = PreferentialAttachment()
-
         cn.fit(adjacency)
-        our_sim = local_similarity.preferential_attachment(
-            nx.from_numpy_array(adjacency))
 
-        indxes = [(random.randrange(adjacency.shape[0]),
-                   random.randrange(adjacency.shape[0])) for a in range(20)]
+        our_sim = local_similarity.preferential_attachment(g)
 
-        for i, j in indxes:
-            expected = cn.predict((i, j))
-            our_res = our_sim[i, j]
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
-            self.assertEqual(expected.round(2), our_res.round(2))
+    def test_preferentialattachment_2(self):
+        g, adjacency = self.__load_medium_dataset()
+
+        cn = PreferentialAttachment()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.preferential_attachment(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
+
+    def test_preferentialattachment_3(self):
+        g, adjacency = self.__load_hard_dataset()
+
+        cn = PreferentialAttachment()
+        cn.fit(adjacency)
+
+        our_sim = local_similarity.preferential_attachment(g)
+
+        self.__perform_sktest(our_sim, cn, adjacency.shape[0])
 
     @unittest.skip("Non è presente in scikit-network")
     def test_cosine(self):

--- a/tests/similarity_methods/test_quasi_local.py
+++ b/tests/similarity_methods/test_quasi_local.py
@@ -1,0 +1,65 @@
+import unittest
+from social_network_link_prediction.similarity_methods import quasi_local_similarity
+from timeout_decorator import timeout
+from tests import Configs
+from time import time
+
+
+class TestQuasiGlobalSimilarityMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.start_time = time()
+
+    def tearDown(self):
+        t = time() - self.start_time
+
+        print(f"{round(t, 2)} s")
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_lpi_1(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_lpi_2(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_lpi_3(self):
+        pass
+
+    # TODO: @ncvesvera @fagiolo ricontrollare
+    @timeout(Configs.timeout)
+    def test_lpi_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+        epsilon = .1
+        n = 4
+
+        res = quasi_local_similarity.local_path_index(g, epsilon, n)
+        # print(res)
+
+        self.assertIsNotNone(res)
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_pol3_1(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_pol3_2(self):
+        pass
+
+    @unittest.skip("Non è presente in scikit-network")
+    def test_pol3_3(self):
+        pass
+
+    @timeout(Configs.timeout)
+    def test_pol3_time(self):
+        g, adjacency = Configs.load_hard_dataset()
+
+        res = quasi_local_similarity.path_of_length_three(g)
+        # print(res)
+
+        self.assertIsNotNone(res)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/similarity_methods/test_quasi_local.py
+++ b/tests/similarity_methods/test_quasi_local.py
@@ -32,7 +32,7 @@ class TestQuasiGlobalSimilarityMethods(unittest.TestCase):
     def test_lpi_time(self):
         g, adjacency = Configs.load_hard_dataset()
         epsilon = .1
-        n = 4
+        n = 10
 
         res = quasi_local_similarity.local_path_index(g, epsilon, n)
         # print(res)


### PR DESCRIPTION
Migliorati unit tests.

- Rimosso un file ora inutile (i test si avviano dal Makefile)
- Riorganizzati test i 4 tipologie:
    - **1:** test di difficoltà _semplice_, vine utilizzato il toy dataset `house`
    - **2:** test di difficoltà _media_, vine utilizzato il toy dataset `karate_club`
    - **3:** test di difficoltà _alta_, vine utilizzato il dataset [ego-faceboog](http://konect.cc/networks/ego-facebook/). Questo test presenta anche un limite di tempo (5 minuti di default) oltre il quale viene considerato fallito.
    - **time:** questo tipo di test è pensato per quei metodi che non hanno un'implementazione già fatta da qualcuno con cui essere confrontata. Utilizzano il dataset 3 e hanno un limite di tempo per essere completati.
- Migliorato codice per test già esistenti
- Aggiunti test per global similarity methods e per quasi local similarity 
- Creata una classe (`Configs.py`) di configurazione dove è possibile cambiare alcuni parametri per i test