### PR TITLE
fix(compatibility): Risolto problema con python < 3.10

### DIFF
--- a/src/social_network_link_prediction/utils/nodes_to_indexes.py
+++ b/src/social_network_link_prediction/utils/nodes_to_indexes.py
@@ -1,8 +1,7 @@
 import networkx as nx
-from typing import Dict, Any
 
 
-def nodes_to_indexes(G: nx.Graph) -> Dict[Any, int]:
+def nodes_to_indexes(G: nx.Graph) -> dict[any, int]:
     """Node Label - Index encoder
 
     Associate, for each node label, and index starting from 0.

--- a/src/social_network_link_prediction/utils/to_adjacency_matrix.py
+++ b/src/social_network_link_prediction/utils/to_adjacency_matrix.py
@@ -1,10 +1,11 @@
 import networkx as nx
 import numpy as np
 from scipy.sparse import csc_matrix
+from typing import Union
 
 
 def to_adjacency_matrix(G: nx.Graph,
-                        sparse: bool = True) -> csc_matrix | np.ndarray:
+                        sparse: bool = True) -> Union[csc_matrix, np.ndarray]:
     """Convert a ginven Graph in to its Adjacency Matrix
 
     Parameters


### PR DESCRIPTION
Risolto un problema che causava il crash della libreria con python < 3.10. Veniva utilizzato l'operatore '|' per specificare che una funzione poteva ritornare 2 valori differenti. Questo è possibile solo da python3.10 in poi.