### PR TITLE
fix(tests): Migliorati Unittest e CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,6 +4,9 @@ on:
     branches: 
       - main
       - develop
+    path:
+      - tests/**
+      - src/**
 
 jobs:
   test:

--- a/tests/unittests/similarity_methods/test_global.py
+++ b/tests/unittests/similarity_methods/test_global.py
@@ -7,76 +7,64 @@ import numpy as np
 
 class TestGlobalSimilarityMethods(unittest.TestCase):
 
+    def __perform_test(self, fun, params: dict = {}, debug: bool = False):
+        g = Configs.load_normal_dataset()
+        g_labels = Configs.load_labels_dataset()
 
-    def __perform_test(self, g, fun, params: dict = {}, debug: bool = False):
-        res = fun(g, **params)
+        res = None
+        res_labels = None
 
-        if debug:
-            print(res)
-            print(type(res))
-    
-        self.assertIsNotNone(res, "None result is returned")
-        self.assertTrue(
-            type(res) is sparse.csr_matrix or type(res) is np.ndarray,
-            "Wrong return type")
-   
+        with self.subTest('Int Labels'):
+            res = fun(g, **params)
+
+            if debug:
+                print(res)
+                print(type(res))
+
+            self.assertIsNotNone(res, "None result is returned")
+            self.assertTrue(
+                type(res) is sparse.csr_matrix or type(res) is np.ndarray,
+                "Wrong return type")
+
+        with self.subTest('String Labels'):
+            res_labels = fun(g_labels, **params)
+
+            if debug:
+                print(res_labels)
+                print(type(res_labels))
+
+            self.assertIsNotNone(res_labels, "None result is returned")
+            self.assertTrue(
+                type(res_labels) is sparse.csr_matrix
+                or type(res_labels) is np.ndarray, "Wrong return type")
+
+        with self.subTest('CMP Results'):
+            try:
+                self.assertTrue(
+                    (res.__round__(4) != res_labels.__round__(4)).nnz == 0,
+                    "Results are different !")
+            except AssertionError as e:
+                print(e)
+
         return res
 
-    def test_katz_nolabels(self):
-        g = Configs.load_normal_dataset()
+    def test_katz(self):
+        self.__perform_test(global_similarity.katz_index, {'beta': .001})
 
-        self.__perform_test(g, global_similarity.katz_index, {'beta': .001})
-
-    def test_katz_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, global_similarity.katz_index, {'beta': .001})
-
-    def test_randwalk_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, global_similarity.link_prediction_rwr, {'c': .05, 'max_iters': 10})
-
-    def test_randwalk_labels(self):
-        g = Configs.load_labels_dataset()
-        
-        self.__perform_test(g, global_similarity.link_prediction_rwr, {
+    def test_randwalk(self):
+        self.__perform_test(global_similarity.link_prediction_rwr, {
             'c': .05,
             'max_iters': 10
         })
 
-    def test_rootedpage_nolabels(self):
-        g = Configs.load_normal_dataset()
+    def test_rootedpage(self):
+        self.__perform_test(global_similarity.rooted_page_rank, {'alpha': .5})
 
-        self.__perform_test(g, global_similarity.rooted_page_rank,
-                            {'alpha': .5})
+    def test_shortestpath(self):
+        self.__perform_test(global_similarity.shortest_path, {'cutoff': None})
 
-    def test_rootedpage_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, global_similarity.rooted_page_rank, {'alpha': .5})
-  
-    def test_shortestpath_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, global_similarity.shortest_path,
-                            {'cutoff': None})
-
-    def test_shortestpath_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, global_similarity.shortest_path,
-                            {'cutoff': None})
-
-    def test_simrank_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, global_similarity.sim_rank)
-
-    def test_simrank_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, global_similarity.sim_rank)
+    def test_simrank(self):
+        self.__perform_test(global_similarity.sim_rank)
 
     # @timeout(Configs.timeout)
     # def test_katz_time(self):

--- a/tests/unittests/similarity_methods/test_local.py
+++ b/tests/unittests/similarity_methods/test_local.py
@@ -7,95 +7,76 @@ import numpy as np
 
 class TestLocalSimilarityMethods(unittest.TestCase):
 
-    def __perform_test(self, g, func, debug = False):
-        sim = func(g)
-        
-        if debug:
-            print(sim)
-            print(type(sim))
-        
-        self.assertIsNotNone(sim, "None result is returned")
-        self.assertTrue(type(sim) is sparse.csr_matrix or type(sim) is np.ndarray, "Wrong return type")
-
-    def test_common_neighbors_nolabels(self):
+    def __perform_test(self, fun, params: dict = {}, debug: bool = False):
         g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.common_neighbors)
+        g_labels = Configs.load_labels_dataset()
 
-    def test_common_neighbors_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.common_neighbors)
-   
-    def test_adamicadar_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.adamic_adar)
+        res = None
+        res_labels = None
 
-    def test_adamicadar_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.adamic_adar)
+        with self.subTest('Int Labels'):
+            res = fun(g, **params)
 
-    def test_jaccard_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.jaccard)
+            if debug:
+                print(res)
+                print(type(res))
 
-    def test_jaccard_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.jaccard)
+            self.assertIsNotNone(res, "None result is returned")
+            self.assertTrue(
+                type(res) is sparse.csr_matrix or type(res) is np.ndarray,
+                "Wrong return type")
 
-    def test_sorensen_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.sorensen)
+        with self.subTest('String Labels'):
+            res_labels = fun(g_labels, **params)
 
-    def test_sorensen_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.sorensen)
+            if debug:
+                print(res_labels)
+                print(type(res_labels))
 
-    def test_hubpromoted_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.hub_promoted)
+            self.assertIsNotNone(res_labels, "None result is returned")
+            self.assertTrue(
+                type(res_labels) is sparse.csr_matrix
+                or type(res_labels) is np.ndarray, "Wrong return type")
 
-    def test_hubpromoted_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.hub_promoted)
+        with self.subTest('CMP Results'):
+            try:
+                self.assertTrue(
+                    (res.__round__(4) != res_labels.__round__(4)).nnz == 0,
+                    "Results are different !")
+            except AssertionError as e:
+                print(e)
 
-    def test_hubdepressed_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.hub_depressed)
+        return res
 
-    def test_hubdepressed_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.hub_depressed)
+    def test_common_neighbors(self):
+        self.__perform_test(local_similarity.common_neighbors)
 
-    def test_resourceallocation_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.resource_allocation)
+    def test_adamicadar(self):
+        self.__perform_test(local_similarity.adamic_adar)
 
-    def test_resourceallocation_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.resource_allocation)
+    def test_jaccard(self):
+        self.__perform_test(local_similarity.jaccard)
 
-    def test_prefattachment_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.preferential_attachment)
+    def test_sorensen(self):
+        self.__perform_test(local_similarity.sorensen)
 
-    def test_prefattachment_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.preferential_attachment)
+    def test_hubpromoted(self):
+        self.__perform_test(local_similarity.hub_promoted)
 
-    def test_cosine_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.cosine_similarity)
+    def test_hubdepressed(self):
+        self.__perform_test(local_similarity.hub_depressed)
 
-    def test_cosine_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.cosine_similarity)
+    def test_resourceallocation(self):
+        self.__perform_test(local_similarity.resource_allocation)
 
-    def test_nodeclustering_nolabels(self):
-        g = Configs.load_normal_dataset()
-        self.__perform_test(g, local_similarity.node_clustering)
+    def test_prefattachment(self):
+        self.__perform_test(local_similarity.preferential_attachment)
 
-    def test_nodeclustering_labels(self):
-        g = Configs.load_labels_dataset()
-        self.__perform_test(g, local_similarity.node_clustering)
+    def test_cosine(self):
+        self.__perform_test(local_similarity.cosine_similarity)
+
+    def test_nodeclustering(self):
+        self.__perform_test(local_similarity.node_clustering)
 
     # def setUp(self):
     #     self.start_time = time()

--- a/tests/unittests/similarity_methods/test_quasi_local.py
+++ b/tests/unittests/similarity_methods/test_quasi_local.py
@@ -7,41 +7,55 @@ import numpy as np
 
 class TestQuasiGlobalSimilarityMethods(unittest.TestCase):
 
-    def __perform_test(self, g, fun, params: dict = {}, debug: bool = False):
-        res = fun(g, **params)
+    def __perform_test(self, fun, params: dict = {}, debug: bool = False):
+        g = Configs.load_normal_dataset()
+        g_labels = Configs.load_labels_dataset()
 
-        if debug:
-            print(res)
-            print(type(res))
+        res = None
+        res_labels = None
 
-        self.assertIsNotNone(res)
-        self.assertTrue(
-            type(res) is sparse.csr_matrix or type(res) is np.ndarray)
+        with self.subTest('Int Labels'):
+            res = fun(g, **params)
+
+            if debug:
+                print(res)
+                print(type(res))
+
+            self.assertIsNotNone(res, "None result is returned")
+            self.assertTrue(
+                type(res) is sparse.csr_matrix or type(res) is np.ndarray,
+                "Wrong return type")
+
+        with self.subTest('String Labels'):
+            res_labels = fun(g_labels, **params)
+
+            if debug:
+                print(res_labels)
+                print(type(res_labels))
+
+            self.assertIsNotNone(res_labels, "None result is returned")
+            self.assertTrue(
+                type(res_labels) is sparse.csr_matrix
+                or type(res_labels) is np.ndarray, "Wrong return type")
+
+        with self.subTest('CMP Results'):
+            try:
+                self.assertTrue(
+                    (res.__round__(4) != res_labels.__round__(4)).nnz == 0,
+                    "Results are different !")
+            except AssertionError as e:
+                print(e)
 
         return res
 
-    def test_LPI_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, quasi_local_similarity.local_path_index, {'epsilon': .1, 'n': 10})
-
-    def test_LPI_labels(self):
-        g = Configs.load_labels_dataset()
-   
-        self.__perform_test(g, quasi_local_similarity.local_path_index, {
+    def test_LPI(self):
+        self.__perform_test(quasi_local_similarity.local_path_index, {
             'epsilon': .1,
             'n': 10
         })
 
-    def test_PL3_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, quasi_local_similarity.path_of_length_three)
-
-    def test_PL3_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, quasi_local_similarity.path_of_length_three)
+    def test_PL3(self):
+        self.__perform_test(quasi_local_similarity.path_of_length_three)
 
     # def setUp(self):
     #     self.start_time = time()

--- a/tests/unittests/test_othermethods.py
+++ b/tests/unittests/test_othermethods.py
@@ -7,29 +7,49 @@ from scipy import sparse
 
 class TestDimensionalityReductionMethods(unittest.TestCase):
 
-    def __perform_test(self, g, fun, params: dict = {}, debug: bool = False):
-        res = fun(g, **params)
+    def __perform_test(self, fun, params: dict = {}, debug: bool = False):
+        g = Configs.load_normal_dataset()
+        g_labels = Configs.load_labels_dataset()
 
-        if debug:
-            print(res)
-            print(type(res))
+        res = None
+        res_labels = None
 
-        self.assertIsNotNone(res, "None result is returned")
-        self.assertTrue(
-            type(res) is sparse.csr_matrix or type(res) is np.ndarray,
-            "Wrong return type")
+        with self.subTest('Int Labels'):
+            res = fun(g, **params)
+
+            if debug:
+                print(res)
+                print(type(res))
+
+            self.assertIsNotNone(res, "None result is returned")
+            self.assertTrue(
+                type(res) is sparse.csr_matrix or type(res) is np.ndarray,
+                "Wrong return type")
+
+        with self.subTest('String Labels'):
+            res_labels = fun(g_labels, **params)
+
+            if debug:
+                print(res_labels)
+                print(type(res_labels))
+
+            self.assertIsNotNone(res_labels, "None result is returned")
+            self.assertTrue(
+                type(res_labels) is sparse.csr_matrix
+                or type(res_labels) is np.ndarray, "Wrong return type")
+
+        with self.subTest('CMP Results'):
+            try:
+                self.assertTrue(
+                    (res.__round__(4) != res_labels.__round__(4)).nnz == 0,
+                    "Results are different !")
+            except AssertionError as e:
+                print(e)
 
         return res
 
-    def test_MI_nolabels(self):
-        g = Configs.load_normal_dataset()
-
-        self.__perform_test(g, other_methods.MI)
-
-    def test_MI_labels(self):
-        g = Configs.load_labels_dataset()
-
-        self.__perform_test(g, other_methods.MI)
+    def test_MI(self):
+        self.__perform_test(other_methods.MI)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ora ogni unittest controlla anche se il risultato del metodo
applicato al grafo con label e senza sono uguali. Se fallisce
non causa errore ma stampa un messaggio di warning.

Ora il workflow viene avviato solo quando ci sono
modifiche hai file nelle cartelle tests/ e src/