### PR TITLE
fix(method): Risolto problema con Jaccard

### DIFF
--- a/cnlp/similarity_methods/local_similarity.py
+++ b/cnlp/similarity_methods/local_similarity.py
@@ -265,7 +265,11 @@ def jaccard(G: nx.Graph) -> csr_matrix:
 
     def __jaccard(G: nx.Graph, x, y) -> float:
         """Compute the Jaccard Coefficient for 2 given nodes."""
-        return __common_neighbors(G, x, y) / len(set(G[x]).union(set(G[y])))
+        total_neighbor_number = len(set(G[x]).union(set(G[y])))
+        if total_neighbor_number == 0:
+            return 0
+        
+        return __common_neighbors(G, x, y) / total_neighbor_number
 
     size = G.number_of_nodes()
     S = lil_matrix((size, size))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='complex-network-link-prediction',
-    version='1.0.1',
+    version='1.0.2',
     license='MIT',
     author=
     "Cristian Cosci, Fabrizio Fagiolo, Nicolò Vescera, Nicolò Posta, Tommaso Romani",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='complex-network-link-prediction',
-    version='1.0',
+    version='1.0.1',
     license='MIT',
     author=
     "Cristian Cosci, Fabrizio Fagiolo, Nicolò Vescera, Nicolò Posta, Tommaso Romani",


### PR DESCRIPTION
- Correzione misura di jaccard per cui risultava una divisione per 0 se i due nodi non sono collegati (singleton)
Co-authored-by: ncvescera <nicolo.vescera@gmail.com>